### PR TITLE
Remove `huggingface_hub.cached_download` import

### DIFF
--- a/WordTransformer/WordTransformer.py
+++ b/WordTransformer/WordTransformer.py
@@ -8,7 +8,7 @@ import requests
 import numpy as np
 from numpy import ndarray
 import transformers
-from huggingface_hub import HfApi, HfFolder, Repository, hf_hub_url, cached_download
+from huggingface_hub import HfApi, HfFolder, Repository, hf_hub_url
 import torch
 from torch import nn, Tensor, device
 from torch.optim import Optimizer


### PR DESCRIPTION
Unused import, was removed in version 0.26 of huggingface_hub: https://github.com/huggingface/huggingface_hub/pull/2579